### PR TITLE
`combined.json` support

### DIFF
--- a/cmd/bridgeconfig.go
+++ b/cmd/bridgeconfig.go
@@ -17,24 +17,8 @@ var (
 		Flags: []cli.Flag{
 			l1Flag,
 			outputFlag,
-			&cli.StringFlag{
-				Name:    rollupManagerAliasFlagName,
-				Aliases: []string{"rm"},
-				Usage: fmt.Sprintf(
-					"Name of the rollup manager to which the rollup belongs. Needs to match an already imported rollup manager (can be done by running the %s command)",
-					importRollupManagerCommandName,
-				),
-				Required: true,
-			},
-			&cli.StringFlag{
-				Name:    rollupAliasFlagName,
-				Aliases: []string{"r"},
-				Usage: fmt.Sprintf(
-					"Name of the rollup. Needs to match an already imported rollup (can be done by running the %s command)",
-					importRollupCommandName,
-				),
-				Required: true,
-			},
+			rollupManagerAliasFlag,
+			rollupAliasFlag,
 		},
 	}
 )

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/urfave/cli/v2"
 )
 
@@ -20,6 +22,24 @@ var (
 		Name:     outputFileFlagName,
 		Aliases:  []string{"o"},
 		Usage:    "Output file",
+		Required: true,
+	}
+	rollupManagerAliasFlag = &cli.StringFlag{
+		Name:    rollupManagerAliasFlagName,
+		Aliases: []string{"rm"},
+		Usage: fmt.Sprintf(
+			"Name of the rollup manager to which the rollup belongs. Needs to match an already imported rollup manager (can be done by running the %s command)",
+			importRollupManagerCommandName,
+		),
+		Required: true,
+	}
+	rollupAliasFlag = &cli.StringFlag{
+		Name:    rollupAliasFlagName,
+		Aliases: []string{"r"},
+		Usage: fmt.Sprintf(
+			"Name of the rollup. Needs to match an already imported rollup (can be done by running the %s command)",
+			importRollupCommandName,
+		),
 		Required: true,
 	}
 )

--- a/cmd/importcombinedjson.go
+++ b/cmd/importcombinedjson.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/0xPolygon/cdk-contracts-tooling/config"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	importCombinedJsonCmd = &cli.Command{
+		Name:    "import-combined-json",
+		Aliases: []string{"import-cj"},
+		Usage:   "Imports the combined.json file to a specified rollup in network files",
+		Action:  importCombinedJson,
+		Flags: []cli.Flag{
+			l1Flag,
+			rollupManagerAliasFlag,
+			rollupAliasFlag,
+		},
+	}
+)
+
+type CombinedJSON struct {
+	RollupManagerAddress       common.Address `json:"polygonRollupManagerAddress"`
+	BridgeAddress              common.Address `json:"polygonZkEVMBridgeAddress"`
+	GlobalExitRootAddress      common.Address `json:"polygonZkEVMGlobalExitRootAddress"`
+	PolTokenAddress            common.Address `json:"polTokenAddress"`
+	RollupManagerCreationBlock uint64         `json:"deploymentRollupManagerBlockNumber"`
+	UpdateToULxLyBlock         uint64         `json:"upgradeToULxLyBlockNumber"`
+	Genesis                    common.Hash    `json:"genesis"`
+	RollupCreationBlock        uint64         `json:"createRollupBlockNumber"`
+	RollupAddress              common.Address `json:"rollupAddress"`
+	ConsensusContract          string         `json:"consensusContract"`
+	RollupID                   uint32         `json:"rollupID"`
+	L2ChainID                  uint64         `json:"L2ChainID"`
+	RollupGasTokenAddress      common.Address `json:"gasTokenAddress"`
+	DACAddress                 common.Address `json:"polygonDataCommitteeAddress"`
+}
+
+func importCombinedJson(cliCtx *cli.Context) error {
+	baseDir, err := checkWorkingDir()
+	if err != nil {
+		return err
+	}
+
+	l1Network := cliCtx.String(l1FlagName)
+	rmAlias := cliCtx.String(rollupManagerAliasFlagName)
+	rAlias := cliCtx.String(rollupAliasFlagName)
+
+	rpcs, rollupManager, rollup, _, err := config.Load(l1Network, rmAlias, rAlias, baseDir)
+	if err != nil {
+		return err
+	}
+
+	client, err := rpcs.GetClient(l1Network)
+	if err != nil {
+		return err
+	}
+
+	if err := rollupManager.InitContract(cliCtx.Context, client); err != nil {
+		return err
+	}
+
+	if err := rollup.InitContract(cliCtx.Context, client); err != nil {
+		return err
+	}
+
+	consensusDesc, err := rollupManager.GetConsensusDescription(cliCtx.Context, rollup.RollupID)
+	if err != nil {
+		return err
+	}
+
+	dac, err := rollup.Contract.DataAvailabilityProtocol(nil)
+	if err != nil {
+		fmt.Println("")
+	}
+
+	combinedJson := &CombinedJSON{
+		RollupManagerAddress:       rollupManager.Address,
+		BridgeAddress:              rollupManager.BridgeAddress,
+		GlobalExitRootAddress:      rollupManager.GERAddr,
+		PolTokenAddress:            rollupManager.POLAddr,
+		RollupManagerCreationBlock: rollupManager.CreationBlock,
+		UpdateToULxLyBlock:         rollupManager.UpdateToULxLyBlock,
+		Genesis:                    rollup.GenesisRoot,
+		RollupCreationBlock:        rollup.CreationBlock,
+		RollupAddress:              rollup.Address,
+		ConsensusContract:          consensusDesc,
+		RollupID:                   rollup.RollupID,
+		L2ChainID:                  rollup.ChainID,
+		RollupGasTokenAddress:      rollup.GasToken,
+		DACAddress:                 dac,
+	}
+
+	raw, err := json.MarshalIndent(combinedJson, "", " ")
+	if err != nil {
+		return err
+	}
+
+	combinedJsonFullPath := path.Join(baseDir, "networks", l1Network, rmAlias, "rollups", rAlias+"-combined.json")
+
+	return os.WriteFile(combinedJsonFullPath, raw, 0644)
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,6 +22,7 @@ func main() {
 		importRollupCommand,
 		nodeGenesisCommand,
 		bridgeConfigCommand,
+		importCombinedJsonCmd,
 	}
 
 	err := app.Run(os.Args)

--- a/rollup/rollup.go
+++ b/rollup/rollup.go
@@ -5,14 +5,15 @@ import (
 	"encoding/json"
 	"os"
 
-	"github.com/0xPolygon/cdk-contracts-tooling/contracts/etrog/polygonzkevm"
+	"github.com/0xPolygon/cdk-contracts-tooling/contracts/elderberry/polygonvalidiumetrog"
 	"github.com/0xPolygon/cdk-contracts-tooling/rollupmanager"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 )
 
 type Rollup struct {
-	Contract      *polygonzkevm.Polygonzkevm `json:"-"`
+	Contract      *polygonvalidiumetrog.Polygonvalidiumetrog `json:"-"`
 	Address       common.Address
 	GenesisRoot   common.Hash
 	CreationBlock uint64
@@ -36,7 +37,7 @@ func LoadFromL1ByChainID(client *ethclient.Client, rm *rollupmanager.RollupManag
 		return nil, err
 	}
 
-	rollup, err := polygonzkevm.NewPolygonzkevm(rData.RollupContract, client)
+	rollup, err := polygonvalidiumetrog.NewPolygonvalidiumetrog(rData.RollupContract, client)
 	if err != nil {
 		return nil, err
 	}
@@ -67,11 +68,27 @@ func LoadFromFile(client *ethclient.Client, filePath string) (*Rollup, error) {
 		return nil, err
 	}
 	if client != nil {
-		contract, err := polygonzkevm.NewPolygonzkevm(r.Address, client)
+		contract, err := polygonvalidiumetrog.NewPolygonvalidiumetrog(r.Address, client)
 		if err != nil {
 			return nil, err
 		}
 		r.Contract = contract
 	}
 	return &r, nil
+}
+
+// InitContract initializes the rollup contract if not already initialized
+func (r *Rollup) InitContract(ctx context.Context, client bind.ContractBackend) error {
+	if r.Contract != nil {
+		return nil
+	}
+
+	contract, err := polygonvalidiumetrog.NewPolygonvalidiumetrog(r.Address, client)
+	if err != nil {
+		return err
+	}
+
+	r.Contract = contract
+
+	return nil
 }

--- a/rollupmanager/rollupmanager.go
+++ b/rollupmanager/rollupmanager.go
@@ -223,7 +223,7 @@ func (rm *RollupManager) InitContract(ctx context.Context, client bind.ContractB
 // GetConsensusDescription returns the description of the consensus for a given rollup ID
 func (rm *RollupManager) GetConsensusDescription(ctx context.Context, rollupID uint32) (string, error) {
 	it, err := rm.Contract.FilterAddNewRollupType(&bind.FilterOpts{
-		Start:   rm.UpdateToULxLyBlock,
+		Start:   rm.CreationBlock,
 		Context: ctx,
 	}, []uint32{rollupID})
 	if err != nil {


### PR DESCRIPTION
This PR adds a new command to the `cdk-contracts-tooling` called `import-combined-json`, which will generate the given file for a selected rollup in this format:

```
{
  "polygonRollupManagerAddress": "0xsomeAddress",
  "polygonZkEVMBridgeAddress": "0xsomeAddress",
  "polygonZkEVMGlobalExitRootAddress": "0xsomeAddress",
  "polTokenAddress": "0xsomeAddress",
  "deploymentRollupManagerBlockNumber": 4794475,
  "upgradeToULxLyBlockNumber": 5157574,
  "genesis": "0xstateroothash",
  "createRollupBlockNumber": 6125289,
  "rollupAddress": "0xsomeAddress",
  "consensusContract": "Type: Validium, Version: eldelberry2, genesis: /ipfs/QmPufMY3NCDcSAxDW3C5QypyycuqHibPN1RVab3CuCDM2n",
  "rollupID": 9,
  "L2ChainID": 419202691,
  "gasTokenAddress": "0xsomeAddress",
  "polygonDataCommitteeAddress": "0xsomeAddress"
}
```

**Command**

**NAME**:
`cdk-contracts import-combined-json` - Imports the combined.json file to a specified rollup in network files

**USAGE**:
`cdk-contracts import-combined-json [command options] [arguments...]`

**OPTIONS**:
`--l1-network value, --l1 value`  - L1 network, such as sepolia, local, goerli, mainnet, ... Should match an entry on the rpcs.toml file
`--rollup-manager-alias value, --rm value` - Name of the rollup manager to which the rollup belongs. Needs to match an already imported rollup manager (can be done by running the import-rollup-manager command)
`--rollup-alias value, -r value` - Name of the rollup. Needs to match an already imported rollup (can be done by running the import-rollup command)
`--help, -h`

**Prerequisites**

1. Rollup manager and rollup json files have been generated using the `import-rollup-manager` and `import-rollup` commands. Currently, tool has json files for rollup managers and rollups for different networks generated in the `networks` folder.
2. Existance of `rcs.toml` file. An example file is located in the repo (`rcs.examples.toml`).

**Command result**

The command will generate a new `rollupName-combined.json` file in the `networks` folder, under the folder where the selected rollup.json was already generated before.