### PR TITLE
Fix `import-rollup-manager` error

### DIFF
--- a/cmd/importrollupmanager.go
+++ b/cmd/importrollupmanager.go
@@ -66,7 +66,7 @@ func importRollupManager(cliCtx *cli.Context) error {
 	fmt.Println("fetching on-chain info for the rollup manager")
 	addrStr := cliCtx.String(rollupManagerAddressFlagName)
 	addr := common.HexToAddress(addrStr)
-	rm, err := rollupmanager.LoadFromL1(client, addr)
+	rm, err := rollupmanager.LoadFromL1(cliCtx.Context, client, addr)
 	if err != nil {
 		return err
 	}

--- a/rollupmanager/rollupmanager.go
+++ b/rollupmanager/rollupmanager.go
@@ -181,6 +181,11 @@ func (rm *RollupManager) GetAttachedRollups(ctx context.Context) (map[uint64]str
 	if err != nil {
 		return nil, err
 	}
+	zeroAddr := common.Address{}
+	if data.RollupContract == zeroAddr {
+		fmt.Println("rollup manager has no attached rollups")
+		return res, nil
+	}
 	rollup, err := polygonzkevm.NewPolygonzkevm(data.RollupContract, rm.Client)
 	if err != nil {
 		return nil, err

--- a/rollupmanager/rollupmanager.go
+++ b/rollupmanager/rollupmanager.go
@@ -126,7 +126,8 @@ type CreateRollupInfo struct {
 
 // GetRollupCreation returns genesis root and the block number in which the rollup was created
 func (rm *RollupManager) GetRollupCreationInfo(ctx context.Context, rollupID uint32) (CreateRollupInfo, error) {
-	if rollupID == 1 {
+	if rollupID == 1 && rm.UpdateToULxLyBlock != rm.CreationBlock {
+		// Original rollup, created before the upgrade
 		rollup, err := polygonzkevm.NewPolygonzkevm(rm.Address, rm.Client)
 		if err != nil {
 			return CreateRollupInfo{}, err


### PR DESCRIPTION
When importing rollup manager which was directly deployed on `uLxLy` mode, the `import-rollup-manager` command throws an error when getting the `CreationBlock`.

This PR fixes this and handles this case.