### PR TITLE
Fix `batchL2Data` encoding (PP rollup)

### DIFF
--- a/cmd/importcombinedjson.go
+++ b/cmd/importcombinedjson.go
@@ -44,7 +44,7 @@ type CombinedJSON struct {
 	RollupGasTokenAddress      common.Address `json:"gasTokenAddress"`
 	DACAddress                 common.Address `json:"polygonDataCommitteeAddress"`
 	BatchL2Data                string         `json:"batchL2Data,omitempty"`
-	LastGlobalExitRoot         common.Hash    `json:"globalExitRoot,omitempty"`
+	RollupGlobalExitRoot       common.Hash    `json:"globalExitRoot,omitempty"`
 }
 
 func importCombinedJson(cliCtx *cli.Context) error {
@@ -77,9 +77,9 @@ func importCombinedJson(cliCtx *cli.Context) error {
 	}
 
 	var (
-		dacAddr            common.Address
-		batchL2Data        string
-		lastGlobalExitRoot common.Hash
+		dacAddr              common.Address
+		batchL2Data          string
+		rollupGlobalExitRoot common.Hash
 	)
 
 	switch rollupMetadata.VerifierType {
@@ -94,7 +94,7 @@ func importCombinedJson(cliCtx *cli.Context) error {
 			return fmt.Errorf("failed to retrieve batch l2 data %w", err)
 		}
 
-		lastGlobalExitRoot, err = r.GetLastGlobalExitRoot(rollupManager, client)
+		rollupGlobalExitRoot, err = r.GetRollupGlobalExitRoot(rollupManager, client)
 		if err != nil {
 			return fmt.Errorf("failed to retrieve batch l2 data %w", err)
 		}
@@ -128,7 +128,7 @@ func importCombinedJson(cliCtx *cli.Context) error {
 		RollupGasTokenAddress:      rollupMetadata.GasToken,
 		DACAddress:                 dacAddr,
 		BatchL2Data:                batchL2Data,
-		LastGlobalExitRoot:         lastGlobalExitRoot,
+		RollupGlobalExitRoot:       rollupGlobalExitRoot,
 	}
 
 	raw, err := json.MarshalIndent(combinedJson, "", "   ")

--- a/cmd/importcombinedjson.go
+++ b/cmd/importcombinedjson.go
@@ -94,7 +94,7 @@ func importCombinedJson(cliCtx *cli.Context) error {
 			return fmt.Errorf("failed to retrieve batch l2 data %w", err)
 		}
 
-		lastGlobalExitRoot, err = r.GetLastGlobalExitRoot(rollupManager.GERAddr, client)
+		lastGlobalExitRoot, err = r.GetLastGlobalExitRoot(rollupManager, client)
 		if err != nil {
 			return fmt.Errorf("failed to retrieve batch l2 data %w", err)
 		}

--- a/networks/sepolia/bali/rollups/BXK Bali.json
+++ b/networks/sepolia/bali/rollups/BXK Bali.json
@@ -1,13 +1,13 @@
 {
-   "Address": "0x646d24e0c845c93beaa0a47df488842a1420943c",
+   "Address": "0x1e000ee8c8c9bb02a38bd981d36dc7c8fac41968",
    "GenesisRoot": "0xc8380fc07613572cabbc1a36d62077e2cd3b0e20bdb56ec521729e71f4c217d6",
-   "CreationBlock": 5578121,
-   "CreationBlockHash": "0xf8cdfa40927495faeef7e198eb2334772effcec6dab37342c181dc5a6dba0c56",
-   "CreationParentBlockHash": "0x64e119992ab46fa0a111a1d34e69385c1af0d4b8973a94c7043ce7c25939912a",
-   "CreationTimestamp": 1711627416,
-   "ChainID": 1000197,
+   "CreationBlock": 5575383,
+   "CreationBlockHash": "0x37dd6575cd0f28fca92c5c7c2c44accf46be575eec1d2ee8cd8831c04cdfd414",
+   "CreationParentBlockHash": "0x7f5cbe106823316d6226a184448f01a7f7c5debff38496a63f5e9c0ae40a0af7",
+   "CreationTimestamp": 1711592184,
+   "ChainID": 10000196,
    "Name": "BXK Bali",
-   "RollupID": 6,
+   "RollupID": 5,
    "GasToken": "0xcde8a097b0406d51e99fc2a99a7ee6c656dd6288",
    "VerifierType": 0
 }

--- a/networks/sepolia/bali/rollups/cdk-validium-01.json
+++ b/networks/sepolia/bali/rollups/cdk-validium-01.json
@@ -1,13 +1,13 @@
 {
-   "Address": "0x0270df078bdaefd6191bea3fa110ded09ec6d239",
-   "GenesisRoot": "0xc8380fc07613572cabbc1a36d62077e2cd3b0e20bdb56ec521729e71f4c217d6",
-   "CreationBlock": 5329690,
-   "CreationBlockHash": "0x44e5d3fb60cf8c2b5fbcb02a2627ff27fc3064a90611224826c8d4cf14919758",
-   "CreationParentBlockHash": "0x51949c1e232a4aaca4341289d5f3e91e20f69a130dbdd13ac409f5d72da91834",
-   "CreationTimestamp": 1708462260,
-   "ChainID": 99902,
+   "Address": "0x83de684f04d8cfdac5f0f18e86868c0292466c9c",
+   "GenesisRoot": "0xba1fbb6c11ba3abc9dbee98d8920b8bd832e531ce9360c6f427ef6bfacebe3d1",
+   "CreationBlock": 5328218,
+   "CreationBlockHash": "0xfe4b7ae88810103251ddd41928b5580e9f8c2f545f4a125698dfd45a00cb41f4",
+   "CreationParentBlockHash": "0x64a27e6185ddff184c6a4f74560158416517afd16aea67db312a655593eb15e5",
+   "CreationTimestamp": 1708443588,
+   "ChainID": 99901,
    "Name": "cdk-validium-01",
-   "RollupID": 3,
+   "RollupID": 2,
    "GasToken": "0x0000000000000000000000000000000000000000",
    "VerifierType": 0
 }

--- a/networks/sepolia/bali/rollups/cdk11.json
+++ b/networks/sepolia/bali/rollups/cdk11.json
@@ -1,0 +1,13 @@
+{
+   "Address": "0x28f7293206792dd933c16c583c4a8f292444a35a",
+   "GenesisRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "CreationBlock": 7203014,
+   "CreationBlockHash": "0x28812f4dad30ebe0a9cc4336546fc37375090f35d59a97a66fa790bde44c65aa",
+   "CreationParentBlockHash": "0x0657d0bf352fd44d7808c7244219a274c2659bd9b1225c634627b001cad6e779",
+   "CreationTimestamp": 1733231304,
+   "ChainID": 461,
+   "Name": "cdk11",
+   "RollupID": 16,
+   "GasToken": "0x0000000000000000000000000000000000000000",
+   "VerifierType": 1
+}

--- a/networks/sepolia/bali/rollups/cdk12.json
+++ b/networks/sepolia/bali/rollups/cdk12.json
@@ -1,0 +1,13 @@
+{
+   "Address": "0x708b70f24faa86a50cdb29fe267cc7c17822812c",
+   "GenesisRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "CreationBlock": 7215718,
+   "CreationBlockHash": "0xe7246d6f7344164afd530b8c16efbb47ee5ab35526fdeaf36ea0ea86a7d4f244",
+   "CreationParentBlockHash": "0x8b210a196ce2fb540e6edfc9d78582e9ace82b668e58c32502b03199803a8025",
+   "CreationTimestamp": 1733393688,
+   "ChainID": 462,
+   "Name": "cdk12",
+   "RollupID": 17,
+   "GasToken": "0x9fff7fae51160924623d235d91970e260be0a22e",
+   "VerifierType": 1
+}

--- a/networks/sepolia/bali/rollups/erigon-cdkintegration10.json
+++ b/networks/sepolia/bali/rollups/erigon-cdkintegration10.json
@@ -1,0 +1,13 @@
+{
+   "Address": "0x3ca5d16d46eb3b7ad9bd3f115cc32d934f27b8dd",
+   "GenesisRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "CreationBlock": 7156503,
+   "CreationBlockHash": "0xdd412b08a764f4fc6429e08fb0ddbed11ef4740eaee6f4eda36f97e9bc95cbb2",
+   "CreationParentBlockHash": "0xf25cd2cdc226b6b0e2e5b3711fc1269f5c49f385f8899660edacf0635c195e64",
+   "CreationTimestamp": 1732625100,
+   "ChainID": 460,
+   "Name": "erigon-cdkintegration10",
+   "RollupID": 15,
+   "GasToken": "0x0000000000000000000000000000000000000000",
+   "VerifierType": 1
+}

--- a/rollup/rollup_pessimistic_proofs.go
+++ b/rollup/rollup_pessimistic_proofs.go
@@ -89,12 +89,14 @@ func (r *RollupPessimisticProofs) GetBatchL2Data(client bind.ContractBackend) (s
 	R := common.BigToHash(big.NewInt(0x5ca1ab1e0))
 	S := common.BigToHash(big.NewInt(0x5ca1ab1e))
 
+	const gasLimit = uint64(30000000)
+
 	bridgeInitTx := types.NewTx(
 		&types.LegacyTx{
 			To:       &bridgeAddr,
 			Value:    common.Big0,
 			GasPrice: common.Big0,
-			Gas:      30000000,
+			Gas:      gasLimit,
 			Nonce:    0,
 			Data:     bridgeInitTxData,
 		})

--- a/rollup/rollup_pessimistic_proofs.go
+++ b/rollup/rollup_pessimistic_proofs.go
@@ -60,7 +60,7 @@ func (r *RollupPessimisticProofs) GetBatchL2Data(client bind.ContractBackend) (s
 		return "", err
 	}
 
-	gasTokenMetadata, err := bridge.GasTokenMetadata(nil)
+	gasTokenMetadata, err := bridge.GetTokenMetadata(nil, r.GasToken)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This PR fixes the `batchL2Data` encoding for pessimistic proofs rollups, by using the `pre-EIP155` transactions, instead of legacy ones.
It also fixes the way `globalExitRoot` is calculated for the pessimistic proofs rollups. Instead of retrieving it from the contract `PolygonZKEVMGlobalExitRoot.GetLastGlobalExitRoot`, we are now tracking the `UpdateL1InfoTree` events and calculating the hash based on the latest event (prior to creation of the rollup).