### PR TITLE
fix: pessimistic proofs - handle zero gas token batchl2data

### DIFF
--- a/cmd/importrollupmanager.go
+++ b/cmd/importrollupmanager.go
@@ -97,7 +97,7 @@ func importRollupManager(cliCtx *cli.Context) error {
 		return err
 	}
 	for chainID, name := range rollups {
-		fmt.Println("importing rollup ", name, " with chainID ", chainID)
+		fmt.Println("importing rollup", name, "with chainID", chainID)
 		r, err := rollup.LoadMetadataFromL1ByChainID(client, rm, chainID)
 		if err != nil {
 			return err

--- a/config/config.go
+++ b/config/config.go
@@ -25,9 +25,10 @@ func Load(l1Network, rmAlias, rAlias, baseDir string) (*RPCs, *rollupmanager.Rol
 		return nil, nil, nil, err
 	}
 
-	fmt.Println("loading the rollup info from file")
 	rollupPath := path.Join(rollupManagerPath, "rollups")
-	r, err := rollup.LoadMetadataFromFile(path.Join(rollupPath, rAlias+".json"))
+	rollupFile := path.Join(rollupPath, rAlias+".json")
+	fmt.Println("loading the rollup info from file", rollupFile)
+	r, err := rollup.LoadMetadataFromFile(rollupFile)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/networks/sepolia/bali/rollups/20-cdk20.json
+++ b/networks/sepolia/bali/rollups/20-cdk20.json
@@ -1,0 +1,13 @@
+{
+   "Address": "0x25d24e2fc03407cee7a653af22bd5ed65b2a2222",
+   "GenesisRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "CreationBlock": 7265676,
+   "CreationBlockHash": "0x1c46f3eecd09aba4c2383611082430dd759fcfe1cfdc812820c776b0d051f985",
+   "CreationParentBlockHash": "0xb1c01b0031139ed5e31ccb07a91af6d3c84de237709cfdbf02376b231c67bd0b",
+   "CreationTimestamp": 1734030720,
+   "ChainID": 465,
+   "Name": "cdk20",
+   "RollupID": 20,
+   "GasToken": "0x0000000000000000000000000000000000000000",
+   "VerifierType": 1
+}

--- a/networks/sepolia/bali/rollups/21-cdk21.json
+++ b/networks/sepolia/bali/rollups/21-cdk21.json
@@ -1,0 +1,13 @@
+{
+   "Address": "0x661e666e33d669eaf73fd287bdfa783652677d45",
+   "GenesisRoot": "0x0000000000000000000000000000000000000000000000000000000000000000",
+   "CreationBlock": 7265676,
+   "CreationBlockHash": "0x1c46f3eecd09aba4c2383611082430dd759fcfe1cfdc812820c776b0d051f985",
+   "CreationParentBlockHash": "0xb1c01b0031139ed5e31ccb07a91af6d3c84de237709cfdbf02376b231c67bd0b",
+   "CreationTimestamp": 1734030720,
+   "ChainID": 466,
+   "Name": "cdk21",
+   "RollupID": 21,
+   "GasToken": "0x72293b2e981d4d0642531357f0792ae1b70bf1ab",
+   "VerifierType": 1
+}


### PR DESCRIPTION
For pessimistic proofs, when gasToken is the native token (0x0 address), the gasTokenMetadata was not initialized on empty byte array and therefore the resulting batchL2Data was incorrect.