### PR TITLE
fix: fetch blocks in chunks when calculating the rollup GER

### DIFF
--- a/cmd/importcombinedjson.go
+++ b/cmd/importcombinedjson.go
@@ -96,7 +96,7 @@ func importCombinedJson(cliCtx *cli.Context) error {
 
 		rollupGlobalExitRoot, err = r.GetRollupGlobalExitRoot(rollupManager, client)
 		if err != nil {
-			return fmt.Errorf("failed to retrieve batch l2 data %w", err)
+			return fmt.Errorf("failed to retrieve the rollup global exit root %w", err)
 		}
 
 	default:


### PR DESCRIPTION
When calculating the rollup GER, the gap (and magnitude of `UpdateL1InfoTree` events was large, more than 20k). This PR caps the block range that is fetched with each RPC call, to overcome this issue.