### PR TITLE
fix: bridge initialize function name

### DIFF
--- a/rollup/rollup_pessimistic_proofs.go
+++ b/rollup/rollup_pessimistic_proofs.go
@@ -81,7 +81,7 @@ func (r *RollupPessimisticProofs) GetBatchL2Data(client bind.ContractBackend) (s
 		return "", err
 	}
 
-	bridgeInitTxData, err := bridgeABI.Pack("initialize0",
+	bridgeInitTxData, err := bridgeABI.Pack("initialize",
 		r.RollupID,
 		r.GasToken,
 		gasTokenNetwork,


### PR DESCRIPTION
The `initialize0` function from bridge is deprecated and we should use the `initialize` one in order to create proper init l2 batch data in the `import-combined-json` command.

### Verification
Run the following command and notice that the combined json is generated without any issues.
```go
go run ./cmd import-combined-json -l1 mainnet -rm mainnet -r 24-Sentient
```